### PR TITLE
adding rtcJsVersion in session report

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,7 +66,24 @@ module.exports = function (grunt) {
                     protocol: 'https'
                 }
             }
-        }
+        },
+        replace: {
+            dist: {
+              options: {
+                patterns: [
+                  {
+                    match: 'RTC_JS_VERSION',
+                    replacement: '<%= pkg.version %>'
+                  }
+                ]
+              },
+              files: [
+                {
+                  expand: true, flatten: true, src: ['out/*.js'], dest: 'out/'
+                }
+              ]
+            }
+          }
     });
 
     grunt.loadNpmTasks('grunt-githooks');
@@ -76,8 +93,8 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-uglify');
     grunt.loadNpmTasks('grunt-contrib-connect');
     grunt.loadNpmTasks('grunt-contrib-watch');
-
-    grunt.registerTask('default', ['eslint', 'browserify', 'uglify']);
+    grunt.loadNpmTasks('grunt-replace');
+    grunt.registerTask('default', ['eslint', 'browserify','replace', 'uglify']);
     grunt.registerTask('lint', ['eslint']);
     grunt.registerTask('build', ['browserify', 'uglify']);
     grunt.registerTask('copyForPublish', ['copy']);

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-eslint": "^21.0.0",
     "grunt-githooks": "^0.6.0",
+    "grunt-replace": "^2.0.2",
     "mocha": "^3.2.0",
     "selenium-webdriver": "^3.3.0",
     "sinon": "^2.1.0",

--- a/src/js/session_report.js
+++ b/src/js/session_report.js
@@ -33,7 +33,7 @@ export class SessionReport {
         this._noRemoteIceCandidateFailure = null;
         this._setRemoteDescriptionFailure = null;
         this._streamStats = [];
-        this._rtcJsVersion = "1.1.17"
+        this._rtcJsVersion = "@@RTC_JS_VERSION"
     }
     /**
      *Timestamp when RTCSession started.

--- a/src/js/session_report.js
+++ b/src/js/session_report.js
@@ -33,6 +33,7 @@ export class SessionReport {
         this._noRemoteIceCandidateFailure = null;
         this._setRemoteDescriptionFailure = null;
         this._streamStats = [];
+        this._rtcJsVersion = "1.1.17"
     }
     /**
      *Timestamp when RTCSession started.
@@ -173,7 +174,13 @@ export class SessionReport {
     get streamStats() {
         return this._streamStats;
     }
-
+    /**
+     * get current connect-rtc-js version
+     */
+    get rtcJsVersion() {
+        return this._rtcJsVersion;
+    }
+    
     set sessionStartTime(value) {
         this._sessionStartTime = value;
     }
@@ -242,5 +249,8 @@ export class SessionReport {
     }
     set streamStats(value) {
         this._streamStats = value;
+    }
+    set rtcJsVersion(value) {
+        this._rtcJsVersion = value;
     }
 }


### PR DESCRIPTION


*Issue #, if available:*
Capturing rtcJsVersion to track deployment status
*Description of changes:*
Adding rtcJsVersion in the softphone call end report. using grunt-replace to read the version number from package.json and replace the placeholder when we run grunt or grunt default.

~~Ideally we should use a string replace plugin like [here](https://github.com/amazon-connect/amazon-connect-streams/blob/12992a4832e1e6631b2b531123c7419491b0dc87/webpack/connect-streams.config.js#L42) to read the version from package.json and replace a dummy string with that version number, but the string replace plugin for grunt are outdated. (grunt-string-replace is deprecated, grunt-text-replace is not updated for 8 years). Hardcoding the version id in the rtcJs report to safely track the emergency fix until we have a better solution~~

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
